### PR TITLE
Updated .travis.yml to point to updated heroku app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
 
 deploy:
   provider: heroku
-  app: polar-shelf-23589
+  app: hobbs-wedding-rsvp
   api_key:
     secure: "bbfea3af-8203-4fc6-a424-5c49b6d2ead1"
   skip_cleanup: true


### PR DESCRIPTION
Any git remotes will also need updating to `https://git.heroku.com/hobbs-wedding-rsvp.git`, if deploying through the command line.

New app url for the bitly link: https://hobbs-wedding-rsvp.herokuapp.com/
