### PR TITLE
Smtp settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # wedding-rsvp
 A site for wedding guests to send RSVPs
 
-[![Build status](https://travis-ci.org/thehobbs/wedding-rsvp.svg?branch=master)](https://travis-ci.org/thehobbs/wedding-rsvp) 
+[![Build status](https://travis-ci.org/thehobbs/wedding-rsvp.svg?branch=master)](https://travis-ci.org/thehobbs/wedding-rsvp)
 [![Code
 Climate](https://codeclimate.com/github/thehobbs/wedding-rsvp/badges/gpa.svg)](https://codeclimate.com/github/thehobbs/wedding-rsvp)
 [![Test
@@ -32,3 +32,14 @@ After getting latest, run `$ npm install` to bring down any possible new node pa
 * [Rails Development Server](http://localhost:3000)
 * [Rails server with BrowserSync](http://localhost:3001) _if the server has been started with `$ gulp server`_
 * [BrowserSync control panel](http://localhost:3002)
+
+## SMTP settings
+
+STMP settings for the site can be specified for local environments by creating a file called `.env` in the root, and specifying the following keys:
+
+````
+SMTP_USERNAME=<your smtp username>
+SMTP_PASSWORD=<your smtp password>
+````
+
+This file should not be committed to the repository.

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,18 +15,6 @@ require "action_view/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-# Load smtp config (if available) and set into the environment
-smtp_path = File.expand_path('../smtp.yml', __FILE__)
-if File.exists? smtp_path
-  smtp = YAML.load_file smtp_path
-  smtp.merge! smtp.fetch(Rails.env, {})
-
-  smtp.each do |key, value|
-    ENV[key] = value.to_s unless value.kind_of? Hash
-  end
-
-end
-
 module WeddingRsvp
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -21,8 +21,8 @@ Rails.application.configure do
     :address        => "smtp.gmail.com",
     :port           => 587,
     :authentication => :plain,
-    :user_name      => ENV['smtp_username'],
-    :password       => ENV['smtp_password'],
+    :user_name      => ENV['SMTP_USERNAME'],
+    :password       => ENV['SMTP_PASSWORD'],
     :openssl_verify_mode  => 'none'
   }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,11 +20,11 @@ Rails.application.configure do
     :address        => "smtp.gmail.com",
     :port           => 587,
     :authentication => :plain,
-    :user_name      => ENV['smtp_username'],
-    :password       => ENV['smtp_password'],
+    :user_name      => ENV['SMTP_USERNAME'],
+    :password       => ENV['SMTP_PASSWORD'],
     :openssl_verify_mode  => 'none'
   }
-  
+
   # Enable Rack::Cache to put a simple HTTP cache in front of your application
   # Add `rack-cache` to your Gemfile before enabling this.
   # For large-scale production use, consider using a caching reverse proxy like


### PR DESCRIPTION
Essentially this PR removes the need for a separate smtp.yml file in /config and instead uses a .env file in the root, courtesy of https://github.com/bkeepers/dotenv.

Associated readme.md change details how to get SMTP settings working locally.

ENV keys on the heroku dyno have already been added to match the change in casing.

Once this PR has been merged, the environment vars `smtp_username` and `smtp_password` (note the casing) on Heroku can be removed.
